### PR TITLE
remove reddit as default app

### DIFF
--- a/res/values/sqlmaps.xml
+++ b/res/values/sqlmaps.xml
@@ -26,7 +26,6 @@
         insert into webapps (name,url,iconUrl) values (\'Twitter\',\'https://mobile.twitter.com\',\'\');
         insert into webapps (name,url,iconUrl) values (\'Google News\',\'https://news.google.com\',\'\');
         insert into webapps (name,url,iconUrl) values (\'Hacker News\',\'https://news.ycombinator.com/\',\'\');
-        insert into webapps (name,url,iconUrl) values (\'Reddit\',\'https://m.reddit.com\',\'\');
     </string>
     
     <string translatable="false" name="dbGetWebapps">


### PR DESCRIPTION
Hi,

The current link to reddit m.reddit.com opens my default browser so I replaced it with reddit.com. However I only see the "we use cookie" banner and everything else is blocked by the third party blocker, which makes the link useless with default webapps config