### PR TITLE
Do not crash on data: uri

### DIFF
--- a/app/src/main/java/com/tobykurien/webapps/webviewclient/WebClient.xtend
+++ b/app/src/main/java/com/tobykurien/webapps/webviewclient/WebClient.xtend
@@ -22,6 +22,7 @@ import com.tobykurien.webapps.activity.WebAppActivity
 import com.tobykurien.webapps.data.Webapp
 import com.tobykurien.webapps.fragment.DlgCertificate
 import com.tobykurien.webapps.utils.Debug
+import java.lang.UnsupportedOperationException
 import java.io.ByteArrayInputStream
 import java.util.HashMap
 import java.util.Set
@@ -299,8 +300,13 @@ class WebClient extends WebViewClient {
 	 */
 	def protected Uri getLoadUri(Uri uri) {
 		if(uri === null) return uri // handle google news links to external sites directly
-		if (uri.getQueryParameter("url") !== null) {
-			return Uri.parse(uri.getQueryParameter("url"))
+		try {
+			if (uri.getQueryParameter("url") !== null) {
+				return Uri.parse(uri.getQueryParameter("url"))
+			}
+		} catch (UnsupportedOperationException e) {
+			// Not a hierarchical uri with a query parameter, like data:
+			return uri
 		}
 		return uri
 	}


### PR DESCRIPTION
`getQueryParameter` does not work on `data:` uri and will cause a crash.

```
AndroidRuntime: Process: com.tobykurien.webapps, PID: 6484
AndroidRuntime: java.lang.UnsupportedOperationException: This isn't a hierarchical URI.
AndroidRuntime: 	at android.net.Uri.getQueryParameter(Uri.java:1678)
AndroidRuntime: 	at com.tobykurien.webapps.webviewclient.WebClient.getLoadUri(WebClient.xtend:302)
AndroidRuntime: 	at com.tobykurien.webapps.webviewclient.WebClient.shouldOverrideUrlLoading(WebClient.xtend:90)
AndroidRuntime: 	at android.webkit.WebViewClient.shouldOverrideUrlLoading(WebViewClient.java:73)
AndroidRuntime: 	at com.android.webview.chromium.WebViewContentsClientAdapter.shouldOverrideUrlLoading(WebViewContentsClientAdapter.java:397)
AndroidRuntime: 	at org.chromium.android_webview.AwContentsClient.shouldIgnoreNavigation(AwContentsClient.java:173)
AndroidRuntime: 	at org.chromium.android_webview.AwContentsClientBridge.shouldOverrideUrlLoading(AwContentsClientBridge.java:389)
AndroidRuntime: 	at org.chromium.base.SystemMessageHandler.nativeDoRunLoopOnce(Native Method)
AndroidRuntime: 	at org.chromium.base.SystemMessageHandler.handleMessage(SystemMessageHandler.java:51)
AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
AndroidRuntime: 	at android.os.Looper.loop(Looper.java:154)
AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6186)
AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
AndroidRuntime: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
ActivityManager:   Force finishing activity com.tobykurien.webapps/.activity.WebAppActivity
```